### PR TITLE
Mark unreleased `highlight` `mark_lines` feature

### DIFF
--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -66,7 +66,7 @@ end
 ```
 {% endraw %}
 
-### Marking specific lines
+### Marking specific lines {%- include docs_version_badge.html version="4.4.0" -%}
 
 You can mark specific lines in a code snippet by using the optional
 argument `mark_lines`. This argument takes a space-separated list of


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The use of `mark_lines` in the `highlight` liquid tag, added in https://github.com/jekyll/jekyll/pull/9138, is merged but not yet released.

The docs on the live site have been updated to reflect this new, but unreleased functionality: https://jekyllrb.com/docs/liquid/tags/#marking-specific-lines. This could be confusing to people... it took me some digging to work out why it wasn't working ;)

I'm not sure if this is the correct approach, but this PR tags the feature in the docs as requiring the upcoming `4.4.0` release...
